### PR TITLE
mjw83735 - staff page behind auth

### DIFF
--- a/app/shifts_controller.py
+++ b/app/shifts_controller.py
@@ -160,10 +160,11 @@ def prep_copy_list(cell_list, copy_list):
         shift['In'] = convert_time_format(shift['In'], 12)
         shift['Out'] = convert_time_format(shift['Out'], 12)
         index = copy_list.index(shift)
-        cell_list[index * 4].value = shift['Name']
-        cell_list[index * 4 + 1].value = shift['Date']
-        cell_list[index * 4 + 2].value = shift['In']
-        cell_list[index * 4 + 3].value = shift['Out']
+        cell_list[index * 5].value = shift['Name']
+        cell_list[index * 5 + 1].value = shift['Date']
+        cell_list[index * 5 + 2].value = shift['In']
+        cell_list[index * 5 + 3].value = shift['Out']
+        cell_list[index * 5 + 4].value = shift['IP Address']
     gsheet_scanner_data.update_cells(cell_list)  # appends to Scanner Data sheet
 
 
@@ -363,7 +364,7 @@ class ShiftsController:
         reset_sheet_data(gsheet_scanner_data, 5)  # clear Scanner Data sheet data prior to re-adding unused shifts
 
         list_row_length = len(copy_list) + 2
-        cell_list = gsheet_scanner_data.range(2, 1, list_row_length, 4)
+        cell_list = gsheet_scanner_data.range(2, 1, list_row_length, 5)
 
         return_to_string(copy_list)
         prep_copy_list(cell_list, copy_list)

--- a/app/shifts_controller.py
+++ b/app/shifts_controller.py
@@ -103,7 +103,7 @@ def flagged_cells(hd_shifts, scan_shifts, hd_row, scan_row, reason, skipped):
     flag_val = [hd_shifts[hd_row]['Shift ID'], hd_shifts[hd_row]['Date'],
                 convert_time_format(hd_shifts[hd_row]['Start Time'], 12),
                 convert_time_format(hd_shifts[hd_row]['End Time'], 12), hd_shifts[hd_row]['Employee Name']]
-    if skipped:
+    if skipped:  # append empty strings so next shift's in and out are not appended
         flag_val.append('')
         flag_val.append('')
     else:
@@ -294,7 +294,7 @@ class ShiftsController:
                     time_in = datetime.strptime(scan_shifts[scan_row]['Date'] +
                                                 scan_shifts[scan_row]['In'], '%x%H:%M')
 
-            if scan_shifts[scan_row]['IP Address'] != '140.88.175':
+            if scan_shifts[scan_row]['IP Address'] != '140.88.175.144':
                 cause = 'Invalid IP: Did not sign in at Service Desk'
                 shift_count = multiple_shifts(cause, flag_key, flag_list, hd_shifts, n, scan_row, scan_shifts,
                                               shift_count, flagged=False)

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -6,16 +6,14 @@
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#sd-navbar" aria-controls="sd-navbar" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
-    {% if session.get('ITS_view') %}
-        <div class="collapse navbar-collapse" id="sd-navbar">
-            <ul class="navbar-nav mr-auto">
-                <li class="nav-item">
-                    <a class="nav-link button {{ 'nav-bar-active' if 'ShiftsView:staff_index' in request.url_rule.endpoint }}" href="{{ url_for('ShiftsView:staff_index') }}">Staff</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link button {{ 'nav-bar-active' if 'ShiftsView:help' in request.url_rule.endpoint }}" href="{{ url_for('ShiftsView:help') }}">Help</a>
-                </li>
-            </ul>
-        </div>
-    {% endif %}
+    <div class="collapse navbar-collapse" id="sd-navbar">
+        <ul class="navbar-nav mr-auto">
+            <li class="nav-item">
+                <a class="nav-link button {{ 'nav-bar-active' if 'ShiftsView:staff_index' in request.url_rule.endpoint }}" href="{{ url_for('ShiftsView:staff_index') }}">Staff</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link button {{ 'nav-bar-active' if 'ShiftsView:help' in request.url_rule.endpoint }}" href="{{ url_for('ShiftsView:help') }}">Help</a>
+            </li>
+        </ul>
+    </div>
 </nav>

--- a/app/templates/staff_index.html
+++ b/app/templates/staff_index.html
@@ -11,11 +11,11 @@
         </div>
         <div class="alert alert-success alert-dismissible" id="processing-complete" style="display: none;">
           <button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times</button>
-          <h6>Shift data processing complete</h6>
+          <h6>Shift data processing complete.</h6>
         </div>
         <div class="alert alert-warning alert-dismissible" id="index-error" style="display: none;">
           <button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times</button>
-          <h6>Error: No shifts entered into Service Desk Schedule sheet.</h6>
+          <h6>Error: Data mismatch between Service Desk Schedule and Scanner Data.</h6>
         </div>
         <h6 class="alert alert-danger" id="resource-exhausted" style="display: none;">Error: Server Exhausted. Please wait 1 minute and try again.</h6>
         <div class="spinner" style="display: none;">

--- a/app/views.py
+++ b/app/views.py
@@ -31,11 +31,12 @@ class ShiftsView(FlaskView):
                 seconds_in_12_hours = 60 * 60 * 12
                 session['session_time'] = time.time() + seconds_in_12_hours
 
+            # if accessing staff-only pages, then get username and check if user has ITS - Employee role in IAM
             if '/staff' in request.path or '/help' in request.path:
                 get_user()
                 get_its_view()
 
-                if session['ITS_view'] is False:
+                if session['ITS_view'] is False:  # after checking ITS_view, if not staff, then abort
                     abort(403)
 
         def get_user():

--- a/app/views.py
+++ b/app/views.py
@@ -66,7 +66,7 @@ class ShiftsView(FlaskView):
             except:
                 session['ITS_view'] = False
 
-        if '/staff' in request.path or '/help' in request.path:
+        if '/staff' in request.path or '/help' in request.path:  # check user if on these pages
             init_user()
 
     @route('/')

--- a/app/views.py
+++ b/app/views.py
@@ -37,7 +37,8 @@ class ShiftsView(FlaskView):
             if 'ITS_view' not in session.keys():
                 get_its_view()
 
-            if session['ITS_view'] is False and app.config['ENVIRON'] == 'prod':
+            if ('/staff' in request.path or '/help' in request.path) and session['ITS_view'] is False and \
+                    app.config['ENVIRON'] == 'prod':
                 abort(403)
 
         def get_user():
@@ -66,8 +67,7 @@ class ShiftsView(FlaskView):
             except:
                 session['ITS_view'] = False
 
-        if '/staff' in request.path or '/help' in request.path:
-            init_user()
+        init_user()
 
     @route('/')
     def index(self):

--- a/app/views.py
+++ b/app/views.py
@@ -31,14 +31,12 @@ class ShiftsView(FlaskView):
                 seconds_in_12_hours = 60 * 60 * 12
                 session['session_time'] = time.time() + seconds_in_12_hours
 
-            if 'username' not in session.keys() or ('/staff' in request.path or '/help' in request.path):
+            if '/staff' in request.path or '/help' in request.path:
                 get_user()
-
-            if 'ITS_view' not in session.keys():
                 get_its_view()
 
-            if session['ITS_view'] is False and ('/staff' in request.path or '/help' in request.path):
-                abort(403)
+                if session['ITS_view'] is False:
+                    abort(403)
 
         def get_user():
             if app.config['ENVIRON'] == 'prod':

--- a/app/views.py
+++ b/app/views.py
@@ -37,7 +37,8 @@ class ShiftsView(FlaskView):
             if 'ITS_view' not in session.keys():
                 get_its_view()
 
-            if session['ITS_view'] is False and app.config['ENVIRON'] == 'prod':
+            if ('/staff' in request.path or '/help' in request.path) and session['ITS_view'] is False and \
+                    app.config['ENVIRON'] == 'prod':
                 abort(403)
 
         def get_user():
@@ -66,7 +67,7 @@ class ShiftsView(FlaskView):
             except:
                 session['ITS_view'] = False
 
-        if '/staff' in request.path or '/help' in request.path:  # check user if on these pages
+        if '/staff' in request.path or '/help' in request.path:
             init_user()
 
     @route('/')

--- a/app/views.py
+++ b/app/views.py
@@ -37,8 +37,7 @@ class ShiftsView(FlaskView):
             if 'ITS_view' not in session.keys():
                 get_its_view()
 
-            if ('/staff' in request.path or '/help' in request.path) and session['ITS_view'] is False and \
-                    app.config['ENVIRON'] == 'prod':
+            if session['ITS_view'] is False and app.config['ENVIRON'] == 'prod':
                 abort(403)
 
         def get_user():
@@ -67,7 +66,8 @@ class ShiftsView(FlaskView):
             except:
                 session['ITS_view'] = False
 
-        init_user()
+        if '/staff' in request.path or '/help' in request.path:
+            init_user()
 
     @route('/')
     def index(self):

--- a/app/views.py
+++ b/app/views.py
@@ -37,8 +37,7 @@ class ShiftsView(FlaskView):
             if 'ITS_view' not in session.keys():
                 get_its_view()
 
-            if ('/staff' in request.path or '/help' in request.path) and session['ITS_view'] is False and \
-                    app.config['ENVIRON'] == 'prod':
+            if session['ITS_view'] is False and app.config['ENVIRON'] == 'prod':
                 abort(403)
 
         def get_user():

--- a/app/views.py
+++ b/app/views.py
@@ -31,7 +31,7 @@ class ShiftsView(FlaskView):
                 seconds_in_12_hours = 60 * 60 * 12
                 session['session_time'] = time.time() + seconds_in_12_hours
 
-            if 'username' not in session.keys():
+            if 'username' not in session.keys() or ('/staff' in request.path or '/help' in request.path):
                 get_user()
 
             if 'ITS_view' not in session.keys():

--- a/app/views.py
+++ b/app/views.py
@@ -72,6 +72,10 @@ class ShiftsView(FlaskView):
     def index(self):
         return render_template('index.html', **locals())
 
+    @route('/test')
+    def test(self):
+        return str(session['username'])
+
     @route('/student-signin')
     def student_signin(self):
         try:

--- a/app/views.py
+++ b/app/views.py
@@ -37,8 +37,7 @@ class ShiftsView(FlaskView):
             if 'ITS_view' not in session.keys():
                 get_its_view()
 
-            if ('/staff' in request.path or '/help' in request.path) and session['ITS_view'] is False and \
-                    app.config['ENVIRON'] == 'prod':
+            if session['ITS_view'] is False and ('/staff' in request.path or '/help' in request.path):
                 abort(403)
 
         def get_user():

--- a/app/views.py
+++ b/app/views.py
@@ -70,10 +70,6 @@ class ShiftsView(FlaskView):
     def index(self):
         return render_template('index.html', **locals())
 
-    @route('/test')
-    def test(self):
-        return str(session['username'])
-
     @route('/student-signin')
     def student_signin(self):
         try:


### PR DESCRIPTION
## Description

First, the IP address check in shifts_controller.py has been updated to reflect the true IP address of the Service Desk kiosk computer. The Process Shift Data button will now analyze the IP correctly when it is run. Second, the init_user method in the before request of views.py has been updated to only check user if accessing the '/staff' or '/help' pages, sending a 403 error if the user is not an ITS staff member. The '/staff' and '/help' pages are now the only two pages behind CAS authentication. More info is also below in the 'Testing' description.

Fixes #11 

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

Tested both locally and on XP. When the user opens the starting page, the tabs for the '/staff' and '/help' pages now show on the navbar, but when a user clicks on them, it shows the CAS login screen. Clicking the 'Start Session' button on the starting page still logs the user out of CAS if they were logged in. Either way, the user will only need to go through CAS to reach the '/staff' and '/help' pages now. Testing has shown that users without the 'ITS - Employees' IAM role will see the abort(403) html page and if they do have the role, they will see the correct html pages as desired.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)