### PR TITLE
Fix Issue 12 for Better Formatting of Alerts

### DIFF
--- a/app/shifts_controller.py
+++ b/app/shifts_controller.py
@@ -5,7 +5,7 @@ from oauth2client.service_account import ServiceAccountCredentials
 # Packages
 import datetime
 from datetime import datetime, timedelta
-from flask import request, session
+from flask import request
 from functools import cmp_to_key
 from operator import itemgetter as i
 
@@ -168,22 +168,6 @@ def prep_copy_list(cell_list, copy_list):
 
 
 class ShiftsController:
-    # sets alert for when one is needed next
-    def set_alert(self, message_type, message):
-        session['alert'].append({
-          'type': message_type,
-          'message': message
-        })
-        session.modified = True
-
-    # gets current alert (if there is one) and then resets alert to nothing
-    def get_alert(self):
-        if 'alert' in session.keys():
-            session['alert'] = []
-        alert_return = session['alert']
-        session['alert'] = []
-        return alert_return
-
     def student_time_clock(self, card_id):
         current_time = datetime.now().strftime('%-I:%M %p')
         current_date = datetime.now().strftime('%x')

--- a/app/shifts_controller.py
+++ b/app/shifts_controller.py
@@ -5,7 +5,7 @@ from oauth2client.service_account import ServiceAccountCredentials
 # Packages
 import datetime
 from datetime import datetime, timedelta
-from flask import request
+from flask import request, session
 from functools import cmp_to_key
 from operator import itemgetter as i
 
@@ -168,6 +168,22 @@ def prep_copy_list(cell_list, copy_list):
 
 
 class ShiftsController:
+    # sets alert for when one is needed next
+    def set_alert(self, message_type, message):
+        session['alert'].append({
+          'type': message_type,
+          'message': message
+        })
+        session.modified = True
+
+    # gets current alert (if there is one) and then resets alert to nothing
+    def get_alert(self):
+        if 'alert' in session.keys():
+            session['alert'] = []
+        alert_return = session['alert']
+        session['alert'] = []
+        return alert_return
+
     def student_time_clock(self, card_id):
         current_time = datetime.now().strftime('%-I:%M %p')
         current_date = datetime.now().strftime('%x')

--- a/app/static/shift_buttons.js
+++ b/app/static/shift_buttons.js
@@ -22,32 +22,14 @@ $(document).ready(function() {
     // method in shifts_controller.py, where it logs the time in/out and returns from views.py as a POST. Along with a
     // loading GIF, the time in/out is appended to the table in shifts_table.html
     let input = "";
-    $(document).on('keydown', function(key) {
+    $(document).on('keydown', function (key) {
         if (key.keyCode === 13) {
-            $('#time-clock-fail').hide();
-            $('#resource-exhausted').hide();
             $('.spinner').show();
             let scanned_input = {
                 'scan': input
             };
-            $.post('/verify_scanner', scanned_input, function (scan_success) {
+            $.post('/verify_scanner', scanned_input, function (data) {
                 $('.spinner').hide();
-                if (scan_success !== 'failed' && scan_success !== 'resource exhausted' && scan_success !== 'no match') {
-                    $('#time-clock-success').fadeTo(3000, 500).slideUp(500, function () {
-                        $("#time-clock-success").slideUp(500);
-                    });
-                    $("#student-tbody").html(scan_success);
-                } else if (scan_success === 'no match') {
-                    $('#time-clock-no-match').fadeTo(3000, 500).slideUp(500, function() {
-                        $("#time-clock-no-match").slideUp(500);
-                    });
-                } else if (scan_success === 'failed') {
-                    $('#time-clock-fail').fadeTo(3000, 500).slideUp(500, function() {
-                        $("#time-clock-fail").slideUp(500);
-                    });
-                } else {
-                    $('#resource-exhausted').show();
-                }
                 input = "";
             });
         } else {

--- a/app/static/shift_buttons.js
+++ b/app/static/shift_buttons.js
@@ -2,19 +2,15 @@ $(document).ready(function() {
     // Clicking the Process Shift Data button displays a loading GIF, triggers the shift_processor method in
     // shifts_controller.py, and returns an alert with the result of the method (success/failure)
     $("#process-shifts").click(function() {
-        $('#resource-exhausted').hide();
-        $('#processing-complete').hide();
+        $('.alert').hide();
         $('.spinner').show();
         let input_data = {};
-        $.post('/process_shifts', input_data, function(output_data) {
+        $.post('/process_shifts', input_data, function(data) {
+            $('#show-alert').html(data);
             $('.spinner').hide();
-            if (output_data === 'shift data processing complete') {
-                $('#processing-complete').show();
-            } else if (output_data === 'index error') {
-                $('#index-error').show();
-            } else {
-                $('#resource-exhausted').show();
-            }
+            $('.alert').fadeTo(3000, 500).slideUp(500, function() {
+                $('.alert').slideUp(500);
+            });
         });
     });
 
@@ -22,14 +18,19 @@ $(document).ready(function() {
     // method in shifts_controller.py, where it logs the time in/out and returns from views.py as a POST. Along with a
     // loading GIF, the time in/out is appended to the table in shifts_table.html
     let input = "";
-    $(document).on('keydown', function (key) {
+    $(document).on('keydown', function(key) {
         if (key.keyCode === 13) {
+            $('.alert').hide();
             $('.spinner').show();
             let scanned_input = {
                 'scan': input
             };
-            $.post('/verify_scanner', scanned_input, function (data) {
+            $.post('/verify_scanner', scanned_input, function(data) {
+                $("#table-refresh").html(data);
                 $('.spinner').hide();
+                $('.alert').fadeTo(3000, 500).slideUp(500, function() {
+                    $('.alert').slideUp(500);
+                });
                 input = "";
             });
         } else {

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -79,10 +79,9 @@
           <h5><u>Time Clock Page</u></h5>
           <h6>How is the page accessed?</h6>
           <p>
-              To reach any page on the Service Desk Sign-In site, users will sign into CAS before reaching a screen with a button to "Start Session", as well as the Staff and Help tabs in the navigation bar above.
-              To access the Time Clock page, where students sign into shifts, click the "Start Session" button to open the list of today's shifts.
-              Clicking the "Start Session" button signs the user out of CAS to ensure that no other user can access their Bethel account information on another Bethel page.
-              See the question below on how students can clock in and out of shifts once they are on this page.
+              To reach the page, students will click the "Start Session" button on the main page to open the list of today's shifts and sign in. Clicking the "Start Session" button signs the user out of CAS to
+              ensure that no other user can access their Bethel account information on another Bethel page from the Service Desk kiosk computer. Accessing the Staff or Help pages can be done via the navigation
+              bar and accessing either page will be preceded by a CAS sign in prompt, ensuring that only ITS full-time staff are able to access theses pages.
           </p>
           <h6>How do the students clock in and out and where is the information stored?</h6>
           <p>

--- a/app/templates/shift_alert.html
+++ b/app/templates/shift_alert.html
@@ -1,0 +1,1 @@
+<h5 class="alert alert-{{ alert_type }}" style="display: none;">{{ alert_message }}</h5>

--- a/app/templates/shifts_table.html
+++ b/app/templates/shifts_table.html
@@ -1,7 +1,21 @@
-{% for shift in day_list %}
-<tr>
-    <td>{{ shift['Name'] }}</td>
-    <td>{{ shift['In'] }}</td>
-    <td>{{ shift['Out'] }}</td>
-</tr>
-{% endfor %}
+<div class="centered">
+    {% include 'shift_alert.html' %}
+</div>
+<table id="student-attendance" class="table table-striped table-bordered">
+    <thead>
+        <tr>
+            <th data-toggle="tooltip" data-placement="top" title="Student Name">Name</th>
+            <th data-toggle="tooltip" data-placement="top" title="Time Signed Into Shift">Time In</th>
+            <th data-toggle="tooltip" data-placement="top" title="Time Signed Out Of Shift">Time Out</th>
+        </tr>
+    </thead>
+    <tbody id="student-tbody">
+        {% for shift in day_list %}
+        <tr>
+            <td>{{ shift['Name'] }}</td>
+            <td>{{ shift['In'] }}</td>
+            <td>{{ shift['Out'] }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/app/templates/staff_index.html
+++ b/app/templates/staff_index.html
@@ -9,6 +9,19 @@
           <input type="button" class="btn btn-success" id="process-shifts" value="Process Shift Data">
           <p class="card-text">Run the shift processor, which analyzes shifts between the Scanner Data and the Service Desk Schedule and posts the "bad" shifts to Flagged Shifts.</p>
         </div>
+
+        {# SHOWS ALERTS #}
+        {% if alert %}
+          {% for a in alert %}
+            <div class="alert alert-{{ a.type }} alert-dismissible fade show" role="alert">
+              {{ a.message }}
+              <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+          {% endfor %}
+        {% endif %}
+
         <div class="alert alert-success alert-dismissible" id="processing-complete" style="display: none;">
           <button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times</button>
           <h6>Shift data processing complete.</h6>

--- a/app/templates/staff_index.html
+++ b/app/templates/staff_index.html
@@ -9,28 +9,9 @@
           <input type="button" class="btn btn-success" id="process-shifts" value="Process Shift Data">
           <p class="card-text">Run the shift processor, which analyzes shifts between the Scanner Data and the Service Desk Schedule and posts the "bad" shifts to Flagged Shifts.</p>
         </div>
-
-        {# SHOWS ALERTS #}
-        {% if alert %}
-          {% for a in alert %}
-            <div class="alert alert-{{ a.type }} alert-dismissible fade show" role="alert">
-              {{ a.message }}
-              <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-          {% endfor %}
-        {% endif %}
-
-        <div class="alert alert-success alert-dismissible" id="processing-complete" style="display: none;">
-          <button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times</button>
-          <h6>Shift data processing complete.</h6>
+        <div id="show-alert">
+          {% include 'shift_alert.html' %}
         </div>
-        <div class="alert alert-warning alert-dismissible" id="index-error" style="display: none;">
-          <button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times</button>
-          <h6>Error: Data mismatch between Service Desk Schedule and Scanner Data.</h6>
-        </div>
-        <h6 class="alert alert-danger" id="resource-exhausted" style="display: none;">Error: Server Exhausted. Please wait 1 minute and try again.</h6>
         <div class="spinner" style="display: none;">
           <img id="img-spinner" class="spinner-img" src="https://cdn1.bethel.edu/images/load.gif" alt="Loading"/>
         </div>

--- a/app/templates/student_signin.html
+++ b/app/templates/student_signin.html
@@ -5,10 +5,12 @@
     <form>
         <div class="centered">
             <h3 id="title-bar">Scan ID to Sign In or Out</h3>
-            <h3 class="alert alert-success" id="time-clock-success" style="display: none;">Scan success</h3>
-            <h3 class="alert alert-danger" id="time-clock-no-match" style="display: none;">Scan failed, user not found</h3>
-            <h3 class="alert alert-danger" id="time-clock-fail" style="display: none;">Scan failed, try again</h3>
-            <h3 class="alert alert-danger" id="resource-exhausted" style="display: none;">Error: Server Exhausted. Please wait 1 minute and try again.</h3>
+            {# SHOWS ALERTS #}
+            {% if alert %}
+              {% for a in alert %}
+                <h3 class="alert alert-{{ a.type }}">{{ a.message }}</h3>
+              {% endfor %}
+            {% endif %}
         </div>
         <div class="spinner" style="display: none;">
             <img id="img-spinner" class="spinner-img" src="https://cdn1.bethel.edu/images/load.gif" alt="Loading"/>

--- a/app/templates/student_signin.html
+++ b/app/templates/student_signin.html
@@ -5,28 +5,13 @@
     <form>
         <div class="centered">
             <h3 id="title-bar">Scan ID to Sign In or Out</h3>
-            {# SHOWS ALERTS #}
-            {% if alert %}
-              {% for a in alert %}
-                <h3 class="alert alert-{{ a.type }}">{{ a.message }}</h3>
-              {% endfor %}
-            {% endif %}
         </div>
         <div class="spinner" style="display: none;">
             <img id="img-spinner" class="spinner-img" src="https://cdn1.bethel.edu/images/load.gif" alt="Loading"/>
         </div>
     </form>
-    <table id="student-attendance" class="table table-striped table-bordered">
-        <thead>
-            <tr>
-                <th data-toggle="tooltip" data-placement="top" title="Student Name">Name</th>
-                <th data-toggle="tooltip" data-placement="top" title="Time Signed Into Shift">Time In</th>
-                <th data-toggle="tooltip" data-placement="top" title="Time Signed Out Of Shift">Time Out</th>
-            </tr>
-        </thead>
-        <tbody id="student-tbody">
-            {% include 'shifts_table.html' %}
-        </tbody>
-    </table>
+    <div id="table-refresh">
+        {% include 'shifts_table.html' %}
+    </div>
 </div>
 {% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -67,9 +67,6 @@ class ShiftsView(FlaskView):
 
         init_user()
 
-        if 'alert' not in session.keys():
-            session['alert'] = []
-
     @route('/')
     def index(self):
         return render_template('index.html', **locals())
@@ -80,7 +77,7 @@ class ShiftsView(FlaskView):
             day_list = self.sc.day_list()
             return render_template('student_signin.html', day_list=day_list)
         except APIError:
-            # displays table of no shifts, since day_list is where the API calls occur
+            # does not display table of shifts since day_list is where the API calls for shift data occur
             return render_template('student_signin.html', **locals())
 
     @route('/verify_scanner', methods=['POST'])
@@ -89,26 +86,25 @@ class ShiftsView(FlaskView):
             form = request.form
             scan = form.get("scan")
             scan_success = re.search("\[\[(.+?)\]\]", scan)
+            day_list = self.sc.day_list()
+            alert_type = 'danger'
+            alert_message = 'Scan failed, please try again'
             try:
                 card_id = int(scan[2:-2])
             except ValueError:
-                self.sc.set_alert('danger', 'Scan failed, try again')
-                return
+                return render_template('shifts_table.html', **locals())
             if scan_success and len(scan[2:-2]) == 5:
+                alert_message = 'Scan failed, user not found'
                 if self.sc.student_time_clock(card_id):
                     day_list = self.sc.day_list()
-                    self.sc.set_alert('success', 'Scan success')
-                    return render_template('shifts_table.html', day_list=day_list)
-                else:
-                    self.sc.set_alert('danger', 'Scan failed, user not found')
-                    return
-            else:
-                self.sc.set_alert('danger', 'Scan failed, try again')
-                return
+                    alert_type = 'success'
+                    alert_message = 'Scan successful'
+            return render_template('shifts_table.html', **locals())
         except APIError as api_error:
+            alert_type = 'danger'
+            alert_message = 'Error: Server exhausted, please wait 1 minute and try again'
             if str(api_error).find("RESOURCE_EXHAUSTED"):
-                self.sc.set_alert('danger', 'Error: Server exhausted, please wait 1 minute and try again')
-                return
+                return render_template('shifts_table.html', **locals())
 
     @route('/staff')
     def staff_index(self):
@@ -118,15 +114,18 @@ class ShiftsView(FlaskView):
     def process_shifts(self):
         try:
             self.sc.shift_processor()
-            self.sc.set_alert('success', 'Shift data processing complete')
-            return
+            alert_type = 'success'
+            alert_message = 'Shift data processing complete'
+            return render_template('shift_alert.html', **locals())
         except IndexError:
-            self.sc.set_alert('success', 'Error: Data mismatch between Service Desk Schedule and Scanner Data')
-            return
+            alert_type = 'warning'
+            alert_message = 'Error: Data mismatch between Service Desk Schedule and Scanner Data'
+            return render_template('shift_alert.html', **locals())
         except APIError as api_error:
+            alert_type = 'danger'
+            alert_message = 'Error: Server exhausted, please wait 1 minute and try again'
             if str(api_error).find("RESOURCE_EXHAUSTED"):
-                self.sc.set_alert('danger', 'Error: Server exhausted, please wait 1 minute and try again')
-                return
+                return render_template('shift_alert.html', **locals())
 
     @route('/help')
     def help(self):


### PR DESCRIPTION
## Description

Previously, alerts were set by returning a string from the Views Python file to the JS post request and showing an HTML div corresponding to the desired alert. Now, alert type and alert messages are set within the Views.py file, rather than in the relevant HTML file for the alert. A new file, shift_alert.html, was created to be able to display an alert to either the Staff or Student page depending on which page the user is on. Both the shifts_table and staff_index HTML files include the shift_alert.html file in them. In summary, this now sets alerts in Python and simply displays them on the HTML page without the Javascript or HTML knowing what the alert type or alert message is. The Views functions return render template for either the shifts_table or shift_alert HTML files, rather than sending strings.

Fixes #12 

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

- Locally and on XP, I tested successful and failed clock-in's to make sure that all the different error messages were displaying correctly. Similarly, I tested successful and failed clicking of the "Process shift data" button on the Staff page to make sure that the error messages displayed correctly there, too. All error messages displayed and went away correctly as desired.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
