### PR TITLE
Quick fixes to shift analyzing

### DIFF
--- a/app/shifts_controller.py
+++ b/app/shifts_controller.py
@@ -305,7 +305,7 @@ class ShiftsController:
                 scan_row += 1
                 continue
 
-            if not start_time - timedelta(hours=1) <= time_in <= start_time + timedelta(hours=1):
+            if not start_time - timedelta(hours=1.5) <= time_in <= start_time + timedelta(hours=1.5):
                 cause = 'Skipped shift'  # also if student forgets to clock in AND out
                 shift_count = multiple_shifts(cause, flag_key, flag_list, hd_shifts, n, scan_row, scan_shifts,
                                               shift_count, flagged=True)
@@ -328,7 +328,11 @@ class ShiftsController:
             if end_time + timedelta(hours=1) < time_out and \
                     scan_shifts[scan_row]['Date'] == scan_shifts[scan_row + 1]['Date']:
                 cause = 'Forgot to clock in or out'
-                scan_shifts[scan_row + 1]['Out'] = scan_shifts[scan_row + 1]['In']
+                next_in = datetime.strptime(scan_shifts[scan_row + 1]['Date'] +
+                                            scan_shifts[scan_row + 1]['In'], '%x%H:%M')
+                if next_in - time_out >= timedelta(minutes=10):
+                    # only replace next shift's out if next in isn't w/in 10 min of current shift's out
+                    scan_shifts[scan_row + 1]['Out'] = scan_shifts[scan_row + 1]['In']
                 scan_shifts[scan_row + 1]['In'] = scan_shifts[scan_row]['Out']
                 scan_shifts[scan_row]['Out'] = ''
                 shift_count = multiple_shifts(cause, flag_key, flag_list, hd_shifts, n, scan_row, scan_shifts,


### PR DESCRIPTION
## Description

Broadens the range for detecting skipped shifts for if the current scanned time in is not within 1.5 hours of the scheduled shift start in either direction (before this it was just 1 hour, but a student signed in over 1 hour after the start of their shift, so it was incorrectly marked as skipped instead of late). Also, it now better tracks the next shift after a student forgets to sign out but has a shift later in the day.

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

- Locally, I ran Justin's list of shifts in the "schedule" sheet, paired with the current data within the "scan data" sheet. Every shift was flagged (or not flagged) as it should be, which fixes the 2 shifts that were flagged incorrectly prior to these changes. The "process shift data" button works the same on XP/Prod as it does Locally.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)