### PR TITLE
Better name checking

### DIFF
--- a/app/shifts_controller.py
+++ b/app/shifts_controller.py
@@ -272,8 +272,8 @@ class ShiftsController:
                 continue
             shift_count = -1  # reset shift counter if this is the first shift of multiple consecutive shifts
 
-            while hd_shifts[n]['Employee Name'] != scan_shifts[scan_row]['Name'] and \
-                    hd_shifts[n]['Employee Name'] != scan_shifts[scan_row - 1]['Name']:
+            while scan_shifts[scan_row]['Name'] not in hd_shifts[n]['Employee Name'] and \
+                    scan_shifts[scan_row - 1]['Name'] not in hd_shifts[n]['Employee Name']:
                 scan_row += 1
 
             time_in = datetime.strptime(scan_shifts[scan_row]['Date'] + scan_shifts[scan_row]['In'], '%x%H:%M')


### PR DESCRIPTION
## Description

Justin's imported schedule of shifts included a student whose name ended with "(deleted)" within the string, as that student no longer works at the Service Desk. Although it would help to remove the student from these shifts, to prevent errors upon running the "process shift data" button, this broadens the checking for whether the scan data shift's name matches the schedule shift's name. Instead of checking for an exact match, this checks for whether the scan data shift's name is a _substring_ of the scheduled shift's name, rather than an exact match.

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

- Locally, I ran the "process shift data" button with this change and everything ran smoothly. Previously, an error alert popped up because the two shift's names being compared did not match exactly. Now, because one is a substring of the other (as one has "(deleted)" at the end of their name, it still matches correctly and the method runs fine.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)