### PR TITLE
disable tls, which should force ssl to work

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -50,6 +50,7 @@ class ShiftsView(FlaskView):
         def get_its_view():
             try:
                 session['ITS_view'] = False
+                ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
                 con = ldap.initialize(app.config['LDAP_CONNECTION_INFO'])
                 con.simple_bind_s('BU\svc-tinker', app.config['LDAP_SVC_TINKER_PASSWORD'])
 


### PR DESCRIPTION
## Description

This is a fix to help the LDAP SSL security issues. I'm not 100% sure if it works, but the code runs normally. I'm hoping to put this branch on the server, then when Jason runs the ldap audit on friday/monday, we will be able to tell if its fixed

Fixes The new LDAP SSL security updates that happen in march.

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

- tested locally, the code runs. I'm not sure if it does anything

## Checklist:

Only check what applies and what you have done.

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
